### PR TITLE
Increase resolution of Cytoscape.js PNG export

### DIFF
--- a/public/javascripts/PPI/ppi-viewer.js
+++ b/public/javascripts/PPI/ppi-viewer.js
@@ -159,7 +159,7 @@ $(function() {
         var $exportButton = h('button', { 'class': 'cy-button' }, [ t("Export PNG") ]);
         $exportButton.addEventListener('click', function(){
             var b64key = 'base64,';
-            var pngData = cy.png();
+            var pngData = cy.png({full:true});
             var b64 = pngData.substring( pngData.indexOf(b64key) + b64key.length );
             var imgBlob = b64toBlob( b64, 'image/png' );
 


### PR DESCRIPTION
PNG export will now export the full graph. Previously it would only export what fit into the view.

This allows users to partially control the resolution of the exported image. Zoom in until the resolution is high enough, then export.

